### PR TITLE
Storing data regarding incorrect input

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,3 @@ repos:
       args: # arguments to configure flake8
         # making isort line length compatible with autopep8
         - "--max-line-length=88"
--   repo: https://github.com/pre-commit/mirrors-autopep8
-    rev: 'v1.5.7'
-    hooks:
-    - id: autopep8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,4 +5,4 @@ repos:
     - id: flake8
       args: # arguments to configure flake8
         # making isort line length compatible with autopep8
-        - "--max-line-length=88"
+        - "--max-line-length=95"

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -27,7 +27,8 @@ def lambda_handler(event):
             # extracting the body of the message
             message = json.loads(eachMessage["Sns"]["Message"])[0]
 
-            # contains all the keys (or fields) and their values to be added into BigQuery.
+            # contains all the keys (or fields)
+            # and their values to be added into BigQuery.
             row = {}
 
             # check if the key values exist in the message sent
@@ -73,7 +74,10 @@ def insert_data(row):
     # load env variables
     project_id = os.environ.get("BIGQUERY_PROJECT_ID")
     dataset_id = os.environ.get("BIGQUERY_DATASET_ID")
-    table_id = os.environ.get("TABLE_ID")
+    if row["purpose_sub_type"] == "attendance":
+        table_id = os.environ.get("TABLE_ID")
+    elif row["purpose_sub_type"] == "incorrect-entry":
+        table_id = os.environ.get("INCORRECT_ENTRY_TABLE_ID")
 
     client = bigquery.Client(project=project_id)
     table_ref = client.dataset(dataset_id).table(table_id)

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -45,7 +45,7 @@ def lambda_handler(event, lambda_context):
                 user_values_length = len(user_values)
 
                 # loop through each ID to create a separate row
-                for i in range(user_values_length):
+                for i in range(len(user_values)):
                     row = {}
 
                     row["attendance_timestamp"] = message["dateTime"]

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -40,9 +40,8 @@ def lambda_handler(event, lambda_context):
                 and (k in message["purpose"]["params"] for k in ("platform", "id"))
             ):
 
-                # extract all ID's in the array
+                # extract all IDs in the array
                 user_values = message["user"]["values"]
-                user_values_length = len(user_values)
 
                 # loop through each ID to create a separate row
                 for i in range(len(user_values)):
@@ -56,7 +55,7 @@ def lambda_handler(event, lambda_context):
                     row["auth_type"] = message["authType"]
                     row["user_id"] = user_values[i]["userID"]
                     row["user_data_validated"] = user_values[i]["valid"]
-                    row["number_of_multiple_entries"] = len(user_values)
+                    row["number_of_entries"] = len(user_values)
 
                     insert_data(row)
 

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -3,8 +3,11 @@ import os
 import logging
 from google.cloud import bigquery
 
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
 
-def lambda_handler(event):
+
+def lambda_handler(event, lambda_context):
     """
     Parses messages sent to liveclassAttendanceEventHandler lambda function.
     Each message needs to have the following fields for row to be inserted:
@@ -18,7 +21,8 @@ def lambda_handler(event):
         - authType
         - user
             - values
-            - userDataValidated
+    When multiple user IDs are entered,
+    each userID and its valid flag is inserted as a seperate row in BigQuery.
     """
     messageBody = event["Records"]
 
@@ -27,8 +31,7 @@ def lambda_handler(event):
             # extracting the body of the message
             message = json.loads(eachMessage["Sns"]["Message"])[0]
 
-            # contains all the keys (or fields)
-            # and their values to be added into BigQuery.
+            # contains all the keys (or fields) and their values to be added into BigQuery.
             row = {}
 
             # check if the key values exist in the message sent
@@ -38,31 +41,28 @@ def lambda_handler(event):
             if all(
                 (k in message for k in ("dateTime", "purpose", "authType", "user"))
                 and (k in message["purpose"] for k in ("type", "subType", "params"))
-                and (k in message["user"] for k in ("values", "userDataValidated"))
+                and (k in message["user"] for k in ("values"))
                 and (k in message["purpose"]["params"] for k in ("platform", "id"))
             ):
+                # parsing through each user ID and its respective valid flag
+                for each in message["user"]["values"]:
+                    # the key values are the column names in the BQ table.
+                    row["timestamp"] = message["dateTime"]
+                    row["purpose_type"] = message["purpose"]["type"]
+                    row["purpose_sub_type"] = message["purpose"]["subType"]
+                    row["platform"] = message["purpose"]["params"]["platform"]
+                    row["platform_id"] = message["purpose"]["params"]["id"]
+                    row["auth_type"] = message["authType"]
+                    row["user_id"] = each["userID"]
+                    row["user_data_validated"] = each["valid"]
 
-                # the key values are the column names in the BQ table.
-                row["timestamp"] = message["dateTime"]
-                row["purpose_type"] = message["purpose"]["type"]
-                row["purpose_sub_type"] = message["purpose"]["subType"]
-                row["platform"] = message["purpose"]["params"]["platform"]
-                row["platform_id"] = message["purpose"]["params"]["id"]
-                row["auth_type"] = message["authType"]
-                row["user_id"] = message["user"]["values"]
-                row["user_data_validated"] = message["user"]["userDataValidated"]
-
-                return insert_data(row)
+                    return insert_data(row)
 
             else:
-                logging.error(
-                    "Encountered missing fields in message: {}".format(message)
-                )
+                logger.info("Encountered missing fields in message: {}".format(message))
 
         else:
-            logging.error(
-                "Encountered missing fields in message: {}".format(eachMessage)
-            )
+            logger.info("Encountered missing fields in message: {}".format(eachMessage))
 
 
 def insert_data(row):
@@ -92,7 +92,6 @@ def insert_data(row):
         return {"statusCode": 200, "body": "All done!"}
 
     else:
-        logging.error(
-            "Encountered errors while inserting row: {}".format(errors))
+        logging.error("Encountered errors while inserting row: {}".format(errors))
         logging.error(row)
         return {"statusCode": 500, "body": "Error in adding row!"}

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -56,7 +56,7 @@ def lambda_handler(event, lambda_context):
                     row["auth_type"] = message["authType"]
                     row["user_id"] = user_values[i]["userID"]
                     row["user_data_validated"] = user_values[i]["valid"]
-                    row["number_of_multiple_entries"] = user_values_length
+                    row["number_of_multiple_entries"] = len(user_values)
 
                     insert_data(row)
 

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -37,19 +37,16 @@ def lambda_handler(event, lambda_context):
             # check if the key values exist in the message sent
             # even if one field is missing,
             #   the row isn't inserted and an error is logged
-
             if all(
                 (k in message for k in ("dateTime", "purpose", "authType", "user"))
                 and (k in message["purpose"] for k in ("type", "subType", "params"))
                 and (k in message["user"] for k in ("values"))
                 and (k in message["purpose"]["params"] for k in ("platform", "id"))
             ):
-                # sets is_multiple_entry
-                # if the length of user input list has more than 1 userID
-                if len(message["user"]["values"]) > 1:
-                    row["is_multiple_entry"] = True
+
                 # parsing through each user ID and its respective valid flag
                 for each in message["user"]["values"]:
+
                     # the key values are the column names in the BQ table.
                     row["attendance_timestamp"] = message["dateTime"]
                     row["purpose_type"] = message["purpose"]["type"]
@@ -59,8 +56,8 @@ def lambda_handler(event, lambda_context):
                     row["auth_type"] = message["authType"]
                     row["user_id"] = each["userID"]
                     row["user_data_validated"] = each["valid"]
-                    print(row)
-                    return insert_data(row)
+
+                    insert_data(row)
 
             else:
                 logger.info("Encountered missing fields in message: {}".format(message))

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -44,6 +44,10 @@ def lambda_handler(event, lambda_context):
                 and (k in message["user"] for k in ("values"))
                 and (k in message["purpose"]["params"] for k in ("platform", "id"))
             ):
+                # sets is_multiple_entry
+                # if the length of user input list has more than 1 userID
+                if len(message["user"]["values"]) > 1:
+                    row["is_multiple_entry"] = True
                 # parsing through each user ID and its respective valid flag
                 for each in message["user"]["values"]:
                     # the key values are the column names in the BQ table.
@@ -63,6 +67,7 @@ def lambda_handler(event, lambda_context):
 
         else:
             logger.info("Encountered missing fields in message: {}".format(eachMessage))
+
 
 def insert_data(row):
     """

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -56,7 +56,7 @@ def lambda_handler(event, lambda_context):
                     row["auth_type"] = message["authType"]
                     row["user_id"] = user_values[i]["userID"]
                     row["user_data_validated"] = user_values[i]["valid"]
-                    row["number_multiple_entries"] = user_values_length
+                    row["number_of_multiple_entries"] = user_values_length
 
                     insert_data(row)
 

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -47,15 +47,15 @@ def lambda_handler(event, lambda_context):
                 # parsing through each user ID and its respective valid flag
                 for each in message["user"]["values"]:
                     # the key values are the column names in the BQ table.
-                    row["timestamp"] = message["dateTime"]
+                    row["attendance_timestamp"] = message["dateTime"]
                     row["purpose_type"] = message["purpose"]["type"]
-                    row["purpose_sub_type"] = message["purpose"]["subType"]
+                    row["purpose_subtype"] = message["purpose"]["subType"]
                     row["platform"] = message["purpose"]["params"]["platform"]
                     row["platform_id"] = message["purpose"]["params"]["id"]
                     row["auth_type"] = message["authType"]
                     row["user_id"] = each["userID"]
                     row["user_data_validated"] = each["valid"]
-
+                    print(row)
                     return insert_data(row)
 
             else:
@@ -74,9 +74,9 @@ def insert_data(row):
     # load env variables
     project_id = os.environ.get("BIGQUERY_PROJECT_ID")
     dataset_id = os.environ.get("BIGQUERY_DATASET_ID")
-    if row["purpose_sub_type"] == "attendance":
-        table_id = os.environ.get("TABLE_ID")
-    elif row["purpose_sub_type"] == "incorrect-entry":
+    table_id = os.environ.get("TABLE_ID")
+
+    if row["purpose_subtype"] == "incorrect-entry":
         table_id = os.environ.get("INCORRECT_ENTRY_TABLE_ID")
 
     client = bigquery.Client(project=project_id)


### PR DESCRIPTION
- Every time a user types incorrect SRN, the user is displayed with a login error. But we did not have any information about whether the user continued to attempt a second time or even if they did, what the initial attempt was. 
- On the frontend, there are now three cases for `purpose_subtype`; `"liveclass"`, `"plio"`, `"incorrect-entry"`. 
- The only change in this code is adding another environment variable: `INCORRECT_ENTRY_TABLE_ID`, which stores the ID for the BQ table that this data is being fed to. 
- whenever the `purpose_subtype` is `"incorrect-login"`, we use that table ID.
- Another change is setting `is_multiple_entry`, if the length of userIDList > 1.