### PR TITLE
support for number of multiple entries

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -45,7 +45,7 @@ def lambda_handler(event, lambda_context):
                 user_values_length = len(user_values)
 
                 # loop through each ID to create a separate row
-                for i in range(user_values_length):
+                for i in range(len(user_values)):
                     row = {}
 
                     row["attendance_timestamp"] = message["dateTime"]

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -40,9 +40,8 @@ def lambda_handler(event, lambda_context):
                 and (k in message["purpose"]["params"] for k in ("platform", "id"))
             ):
 
-                # extract all ID's in the array
+                # extract all IDs in the array
                 user_values = message["user"]["values"]
-                user_values_length = len(user_values)
 
                 # loop through each ID to create a separate row
                 for i in range(len(user_values)):
@@ -56,7 +55,7 @@ def lambda_handler(event, lambda_context):
                     row["auth_type"] = message["authType"]
                     row["user_id"] = user_values[i]["userID"]
                     row["user_data_validated"] = user_values[i]["valid"]
-                    row["number_of_multiple_entries"] = len(user_values)
+                    row["number_of_entries"] = len(user_values)
 
                     insert_data(row)
 

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -56,7 +56,7 @@ def lambda_handler(event, lambda_context):
                     row["auth_type"] = message["authType"]
                     row["user_id"] = user_values[i]["userID"]
                     row["user_data_validated"] = user_values[i]["valid"]
-                    row["number_of_multiple_entries"] = user_values_length
+                    row["number_of_multiple_entries"] = len(user_values)
 
                     insert_data(row)
 

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -56,7 +56,7 @@ def lambda_handler(event, lambda_context):
                     row["auth_type"] = message["authType"]
                     row["user_id"] = user_values[i]["userID"]
                     row["user_data_validated"] = user_values[i]["valid"]
-                    row["number_multiple_entries"] = user_values_length
+                    row["number_of_multiple_entries"] = user_values_length
 
                     insert_data(row)
 


### PR DESCRIPTION
Whenever a user enters multiple inputs, all the ID's get recorded in BQ. But there was no information about which ID's were typed together or to figure out how much this feature is being used. 

This code stores the length of the user values, which contains each ID and its valid flag, in BQ. 
Example of how the input to the lambda looks like: 
`
{'dateTime': '2021-11-03T08:49:39.365Z', 'purpose': {'type': 'staging', 'subType': 'liveclass', 'params': {'platform': 'meet', 'id': 'eig-ioxa-rvj'}}, 'authType': 'SRN', 'user': {'values': [{'userID': '1111111111', 'valid': True}, {'userID': '1231231231', 'valid': False}, {'userID': '1111111110', 'valid': True}]}}
`

This code has not been deployed yet. Will be after review.